### PR TITLE
feat: add new ssh user

### DIFF
--- a/lib/utils/git-config-set.ts
+++ b/lib/utils/git-config-set.ts
@@ -13,12 +13,12 @@ export const git_config_set = async (username: string) => {
     const section = accounts.find((account: Record<string, string | string[]> | undefined) => account?.User === username);
 
     if (record) {
-      execSync(`git config user.name ${record.name}`, { stdio: [] });
-      execSync(`git config user.email ${record.email}`, { stdio: [] });
+      execSync(`git config user.name "${record.name}"`, { stdio: [] });
+      execSync(`git config user.email "${record.email}"`, { stdio: [] });
     }
 
     if (section) {
-      execSync(`git config core.sshCommand "ssh -i ${section.IdentityFile[0]} -F /dev/null"`)
+      execSync(`git config core.sshCommand "ssh -o IdentitiesOnly=yes -i ${section.IdentityFile[0]} -F /dev/null"`)
     }
   } catch (err: unknown) {
 

--- a/lib/utils/ssh-keys-create.ts
+++ b/lib/utils/ssh-keys-create.ts
@@ -1,0 +1,27 @@
+import { execSync } from 'node:child_process';
+import { note } from '@clack/prompts';
+
+export const ssh_keys_create = async (options: { username: string, name: string; email: string; passphrase: string }): Promise<string | undefined> => {
+  try {
+    const key = `~/.ssh/id_ed25519_${options.username}`;
+
+    execSync(`ssh-keygen -t ed25519 -C "${options.email}" -f ${key} -P "${options.passphrase}"`);
+
+    note(`
+      Open a new shell and run this command to copy your public key:
+      \n
+      pbcopy < ${key}.pub
+      \n
+      Now head over to https://github.com/settings/keys
+      Click "New SSH key"
+      Give your key a Title (e.g. id_ed25519_${options.username})
+      Key type should be Authentication Key
+      Paste in your public Key and save
+    `, 'Instructions');
+
+    return key;
+  } catch (err: unknown) {
+    //
+    console.log('err : ', err);
+  }
+}


### PR DESCRIPTION
Basic functionality for adding a new ssh user:
- creates keys
- updates `~/.ssh/config`
- adds keys to agent
- sets new user to work in the git repo