### PR TITLE
Adding Linux Support

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -24,6 +24,7 @@ interface IPrechecks {
   keys: string[];
   gitrepo: string;
   gitconfig: IGitConfig;
+  distribution: string;
 }
 
 const banner = async () => {
@@ -33,11 +34,11 @@ const banner = async () => {
 };
 
 const init = async () => {
-  const unix = await os_check();
+  const distribution = await os_check();
 
-  if (!unix) {
+  if (distribution === undefined || (!distribution.includes('Darwin') && !distribution.includes('Linux'))) {
     console.log(
-      `MacOS support only. 🙏 see ${chalk.blue.underline(
+      `Your OS is currently not supported! 🙏 See ${chalk.blue.underline(
         homepage
       )} to contribute.`
     );
@@ -57,10 +58,11 @@ const init = async () => {
     keys,
     gitrepo,
     gitconfig,
+    distribution,
   };
 };
 
-const main = async ({ accounts, keys, gitrepo, gitconfig }: IPrechecks) => {
+const main = async ({ accounts, keys, gitrepo, gitconfig, distribution }: IPrechecks) => {
   let linked_user;
   let project: string = '';
   const is_restore = process.argv?.[2] === 'restore';
@@ -100,6 +102,7 @@ const main = async ({ accounts, keys, gitrepo, gitconfig }: IPrechecks) => {
       project,
       users,
       gitconfig: gitconfig,
+      distribution,
     });
   } else {
     const repository = await text({
@@ -118,6 +121,7 @@ const main = async ({ accounts, keys, gitrepo, gitconfig }: IPrechecks) => {
       project,
       users,
       gitconfig: gitconfig,
+      distribution
     });
 
     await clone_repo_user_link({

--- a/lib/utils/os-check.ts
+++ b/lib/utils/os-check.ts
@@ -3,14 +3,10 @@ import { promisify } from 'node:util';
 
 const execAsync = promisify(exec);
 
-export const os_check = async (): Promise<boolean> => {
+export const os_check = async (): Promise<string | undefined> => {
   try {
-    const unix = await execAsync('uname -s')
-      .then(({ stdout }) => stdout.includes('Darwin'))
-      .catch(() => false);
+    const { stdout } = await execAsync('uname -s');
 
-    return unix;
-  } catch (error: unknown) {
-    return false;
-  }
+    return stdout;
+  } catch (error: unknown) {}
 };

--- a/lib/utils/ssh-keys-create.ts
+++ b/lib/utils/ssh-keys-create.ts
@@ -1,10 +1,13 @@
-import { execSync } from 'node:child_process';
-import { cancel, confirm, isCancel, note } from '@clack/prompts';
+import { execSync, exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { cancel, confirm, note } from '@clack/prompts';
 import chalk from 'chalk';
 
 import { HOSTS } from '../consts/hosts.js';
 import { TGithub, TGitlab } from '../types/symbols.js';
 import { ssh_keyscan_known_hosts } from './ssh-keyscan-known-hosts.js';
+
+const execAsync = promisify(exec);
 
 interface IKeysCreate {
   host: TGithub | TGitlab;
@@ -23,17 +26,18 @@ export const ssh_keys_create = async ({
 }: IKeysCreate): Promise<string | undefined> => {
   try {
     const key = `~/.ssh/id_ed25519_${username}`;
-    const copy_command = `pbcopy < ${key}.pub`;
 
     execSync(
       `ssh-keygen -t ed25519 -C "${email}" -f ${key} -P "${passphrase}"`
     );
 
+    const { stdout } = await execAsync(`cat ${key}.pub`);
+
     note(
       `
-      Open a new shell and run this command to copy your public key:
+      Copy your public key below:
       \n
-      ${chalk.inverse(copy_command)}
+      ${chalk.inverse(stdout)}
       \n
       Now head over to ${chalk.blue.underline(HOSTS[host]['keys'])}
       \n

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-account-switch-ssh",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "git-account-switch-ssh",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@clack/core": "^0.3.4",
@@ -1355,9 +1355,9 @@
       }
     },
     "node_modules/@semantic-release/npm/node_modules/execa": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.0.1.tgz",
-      "integrity": "sha512-U5ck8xJmf3sVebV1v+Hh436VWHVHUfzkdbKJynd3kCP9sQRDxCY5x2Tml5lGB7XM6lpj6ATfgWWqynDt2MBLJg==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.0.2.tgz",
+      "integrity": "sha512-oO281GF7ksH/Ogv1xyDf1prvFta/6/XkGKxRUvA3IB2MU1rCJGlFs86HRZhdooow1ISkR0Np0rOxUCIJVw36Rg==",
       "dev": true,
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",


### PR DESCRIPTION
First of all, well done with the work so far! I really appreciate it. However, as a Linux user, I've found that the project doesn't support Linux yet. This pull request aims to change that by adding Linux support. Here's what it includes:

- **Validation Message Update:** Changed the validation OS message from "MacOS support only" to "Your OS is currently not supported!" Now both MacOS and Linux distributions are supported. Windows support is still missing.

- **Keychain Step Removal for Linux:** Removed the Apple Keychain step for Linux machines since it's not applicable.

- **os_check Function Update:** Replaced the boolean return in the os_check function with a string (the `uname` value) as it's needed in multiple places now.

- **pbcopy Replacement:** Replaced the `pbcopy` command with `cat`, which is universal across all system operations. Now, inside the instruction box, it shows the SSH key value to be copied.

Testing:

- Ubuntu 22.04