### PR TITLE
revert: removing linux support since printing key breaks instructions

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -25,7 +25,6 @@ interface IPrechecks {
   keys: string[];
   gitrepo: string;
   gitconfig: IGitConfig;
-  distribution: string;
 }
 
 const { version, homepage } = JSON.parse(
@@ -39,14 +38,11 @@ const banner = async () => {
 };
 
 const init = async () => {
-  const distribution = await os_check();
+  const unix = await os_check();
 
-  if (
-    distribution === undefined ||
-    (!distribution.includes('Darwin') && !distribution.includes('Linux'))
-  ) {
+  if (!unix) {
     console.log(
-      `Your OS is currently not supported! 🙏 See ${chalk.blue.underline(
+      `MacOS support only. 🙏 See ${chalk.blue.underline(
         homepage
       )} to contribute.`
     );
@@ -66,17 +62,10 @@ const init = async () => {
     keys,
     gitrepo,
     gitconfig,
-    distribution,
   };
 };
 
-const main = async ({
-  accounts,
-  keys,
-  gitrepo,
-  gitconfig,
-  distribution,
-}: IPrechecks) => {
+const main = async ({ accounts, keys, gitrepo, gitconfig }: IPrechecks) => {
   let linked_user;
   let project: string = '';
   const is_restore = process.argv?.[2] === 'restore';
@@ -116,7 +105,6 @@ const main = async ({
       project,
       users,
       gitconfig: gitconfig,
-      distribution,
     });
   } else {
     const repository = await text({
@@ -135,7 +123,6 @@ const main = async ({
       project,
       users,
       gitconfig: gitconfig,
-      distribution,
     });
 
     await clone_repo_user_link({

--- a/lib/utils/os-check.ts
+++ b/lib/utils/os-check.ts
@@ -3,10 +3,14 @@ import { promisify } from 'node:util';
 
 const execAsync = promisify(exec);
 
-export const os_check = async (): Promise<string | undefined> => {
+export const os_check = async (): Promise<boolean> => {
   try {
-    const { stdout } = await execAsync('uname -s');
+    const unix = await execAsync('uname -s')
+      .then(({ stdout }) => stdout.includes('Darwin'))
+      .catch(() => false);
 
-    return stdout;
-  } catch (error: unknown) {}
+    return unix;
+  } catch (error: unknown) {
+    return false;
+  }
 };

--- a/lib/utils/ssh-keys-create.ts
+++ b/lib/utils/ssh-keys-create.ts
@@ -1,13 +1,10 @@
-import { execSync, exec } from 'node:child_process';
-import { promisify } from 'node:util';
+import { execSync } from 'node:child_process';
 import { cancel, confirm, note } from '@clack/prompts';
 import chalk from 'chalk';
 
 import { HOSTS } from '../consts/hosts.js';
 import { TGithub, TGitlab } from '../types/symbols.js';
 import { ssh_keyscan_known_hosts } from './ssh-keyscan-known-hosts.js';
-
-const execAsync = promisify(exec);
 
 interface IKeysCreate {
   host: TGithub | TGitlab;
@@ -26,18 +23,17 @@ export const ssh_keys_create = async ({
 }: IKeysCreate): Promise<string | undefined> => {
   try {
     const key = `~/.ssh/id_ed25519_${username}`;
+    const copy_command = `pbcopy < ${key}.pub`;
 
     execSync(
       `ssh-keygen -t ed25519 -C "${email}" -f ${key} -P "${passphrase}"`
     );
 
-    const { stdout } = await execAsync(`cat ${key}.pub`);
-
     note(
       `
-      Copy your public key below:
+      Open a new shell and run this command to copy your public key:
       \n
-      ${chalk.inverse(stdout)}
+      ${chalk.inverse(copy_command)}
       \n
       Now head over to ${chalk.blue.underline(HOSTS[host]['keys'])}
       \n


### PR DESCRIPTION
Removing linux support until we can find a different solution. Printing the public key within the `note` (Instructions) causes the clack prompts to have unusual formatting unless the width of the shell is fairly wide.

<img width="837" alt="key-length-breaks-instruction-notes" src="https://github.com/eric-vandenberg/git-account-switch-ssh/assets/8475435/49cca275-6139-4d3f-ba9d-4e7988109a55">
